### PR TITLE
Option of transferring permissions when copying file

### DIFF
--- a/GoogleApiSupport/drive.py
+++ b/GoogleApiSupport/drive.py
@@ -1,5 +1,92 @@
 from GoogleApiSupport import auth
+from apiclient import errors
 
+# Permissions functions
+
+# https://developers.google.com/drive/api/v2/reference/permissions/list
+def retrieve_permissions(file_id, **kwargs):
+  """Retrieve a list of permissions.
+  Args:
+    file_id: ID of the file to retrieve permissions for.
+  Returns:
+    List of permissions.
+  """
+  service = auth.get_service("drive")
+  try:
+    permissions = service.permissions().list(fileId=file_id, **kwargs).execute()
+    return permissions.get('permissions', [])
+  except errors.HttpError as error:
+    print('An error occurred: %s' % error)
+  return None
+
+# https://developers.google.com/drive/api/v2/reference/permissions/insert
+def insert_permission(file_id, perm_type, role, email_address=None, domain=None, **kwargs):
+  """Insert a new permission.
+  Args:
+    file_id: ID of the file to insert permission for.
+    email_address: User or group e-mail address (needed if perm_type is 'user' or 'group')
+    domain: Domain name (needed if perm_type is 'domain')
+    perm_type: The value 'user', 'group', 'domain', 'anyone' or 'default'.
+    role: The value 'owner', 'writer' or 'reader'.
+  Returns:
+    The inserted permission if successful, None otherwise.
+  """
+  service = auth.get_service("drive")
+  new_permission = {
+      'type': perm_type,
+      'role': role,
+      'emailAddress': email_address,
+      'domain': domain
+  }
+  try:
+    return service.permissions().create(
+        fileId=file_id, body=new_permission, **kwargs).execute()
+  except errors.HttpError as error:
+    print('An error occurred: %s' % error)
+  return None
+
+
+def copy_permissions(start_file_id, end_file_id, **kwargs):
+    """Copy permissions from one file to another.
+    Args:
+    start_file_id: ID of the file to retrieve permissions for.
+    end_file_id: ID of the file to insert permission for.
+    Returns:
+    The copied permissions if successful, None otherwise.
+    """
+    
+    # Values of needed kwargs
+    retrieve_fields = kwargs['fields'] if 'fields' in kwargs else '*'
+    support_all_drives = kwargs['supportsAllDrives'] if 'supportsAllDrives' in kwargs else False
+    transfer_ownership = kwargs['transferOwnership'] if 'transferOwnership' in kwargs else False
+
+    # Retrieve permissions
+    start_permissions = retrieve_permissions(file_id=start_file_id, fields=retrieve_fields)
+
+    # Insert permissions one by one
+    for permission in start_permissions:
+        perm_type = permission['type']
+        # Ownership transfers are not supported for files and folders in shared drives. - OR maybe yes with additional arg "supportAllDrives"
+        # Owndership transfer is only possible if service account has domain-wide authority
+        if transfer_ownership == False and permission['role'] == 'owner':
+            role = 'writer'
+        else:
+            role = permission['role']
+        # value: User or group e-mail address, domain name or None for  for 'anyone' or 'default' type.
+        email_address = permission['emailAddress'] if perm_type in ('user', 'group') else None
+        domain = permission['domain'] if perm_type == 'domain' else None
+            
+        try:
+            return insert_permission(file_id=end_file_id,
+                                     perm_type=perm_type,
+                                     role=role,
+                                     email_address=email_address,
+                                     domain=domain,
+                                     supportsAllDrives=support_all_drives,
+                                     transferOwnership=transfer_ownership)
+        except errors.HttpError as error:
+            print('An error occurred: %s' % error)
+        return None
 
 def get_file_name(file_id):
     service = auth.get_service("drive")
@@ -32,7 +119,7 @@ def delete_file(file_id):
     return response
 
 
-def copy_file(file_from_id, new_file_name='', suppots_all_drives = False):
+def copy_file(file_from_id, new_file_name='', supports_all_drives=False, copy_permissions=False, **kwargs):
     """
     By passing an old file id, creates a copy and returns the id of the file copy
     """
@@ -42,10 +129,14 @@ def copy_file(file_from_id, new_file_name='', suppots_all_drives = False):
     service = auth.get_service("drive")
     drive_response = service.files().copy(fileId=file_from_id,
                                           body=body,
-                                          supportsAllDrives=suppots_all_drives,
+                                          supportsAllDrives=supports_all_drives,
                                           ).execute()
-
+    
     new_file_id = drive_response.get('id')
+    
+    if copy_permissions:
+        copy_permissions(start_file_id=file_from_id, end_file_id=new_file_id, **kwargs)
+
     return new_file_id
 
 

--- a/GoogleApiSupport/drive.py
+++ b/GoogleApiSupport/drive.py
@@ -56,7 +56,8 @@ def copy_permissions(start_file_id, end_file_id, **kwargs):
     retrieve_fields = kwargs['fields'] if 'fields' in kwargs else '*'
     supports_all_drives = kwargs['supportsAllDrives'] if 'supportsAllDrives' in kwargs else False
     transfer_ownership = kwargs['transferOwnership'] if 'transferOwnership' in kwargs else False
-
+    send_notification_email = kwargs['sendNotificationEmail'] if 'sendNotificationEmail' in kwargs and transfer_ownership == False else True
+    
     # Retrieve permissions
     start_permissions = retrieve_permissions(file_id=start_file_id, fields=retrieve_fields)
 
@@ -78,7 +79,8 @@ def copy_permissions(start_file_id, end_file_id, **kwargs):
                                      email_address=email_address,
                                      domain=domain,
                                      supportsAllDrives=supports_all_drives,
-                                     transferOwnership=transfer_ownership)
+                                     transferOwnership=transfer_ownership,
+                                     sendNotificationEmail=send_notification_email)
             end_permissions = end_permissions.append(new_permission)
         except errors.HttpError as error:
             print('An error occurred: %s' % error)

--- a/docs/examples/copy_file_with_permissions.ipynb
+++ b/docs/examples/copy_file_with_permissions.ipynb
@@ -1,0 +1,151 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Copy file and transfer its permissions\n",
+    "\n",
+    "As mentioned in the [issue #28](https://github.com/vperezb/google-api-support/issues/28), when copying a file with a service account, the main user doesn't have access to the new file, unless the entire folder was shared with the service account (and the user).\n",
+    "\n",
+    "To solve this issue, the option was added to copy the permissions from the original file to the new file.\n",
+    "\n",
+    "I will run this example with this [file](https://docs.google.com/presentation/d/1dn4QliG5lY2CVp5TbRWwlgnyWPY6L7wrTOCbBQVgZHA/) from my personal drive to which I have given the following additional permissions:\n",
+    "* editor to the service account\n",
+    "* viewer to everyone that has the link\n",
+    "\n",
+    "To show the effectiveness of this added option, I will copy the file twice and compare results:\n",
+    "1. without copying permissions\n",
+    "2. with copying permissions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Doing this to import the changed version of the library\n",
+    "import sys\n",
+    "sys.path.append('../../GoogleApiSupport')\n",
+    "import drive"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Credentials\n",
+    "import os\n",
+    "ROOT_DIR=os.getcwd()\n",
+    "os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = os.path.join(ROOT_DIR, \"../../.credentials/service_credentials.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start_file_id='1dn4QliG5lY2CVp5TbRWwlgnyWPY6L7wrTOCbBQVgZHA'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Without copying permissions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Copying file 1dn4QliG5lY2CVp5TbRWwlgnyWPY6L7wrTOCbBQVgZHA with name Test_Presentation_Without_Permissions\n",
+      "Output file id without copying permissions: 1XN7jMudvbAXEpXVvUhftL60fKUg6yqdSbyjaDvzRHkQ\n"
+     ]
+    }
+   ],
+   "source": [
+    "new_file_id_without = drive.copy_file(file_from_id=start_file_id, new_file_name='Test_Presentation_Without_Permissions')\n",
+    "print('Output file id without copying permissions:', new_file_id_without)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can attest by trying to access this [file](https://docs.google.com/presentation/d/1XN7jMudvbAXEpXVvUhftL60fKUg6yqdSbyjaDvzRHkQ/), this is not possible as the only permission is the owner which is the service account."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### With copying permissions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Copying file 1dn4QliG5lY2CVp5TbRWwlgnyWPY6L7wrTOCbBQVgZHA with name Test_Presentation_With_Permissions\n",
+      "Successfully transferred permissions from file 1dn4QliG5lY2CVp5TbRWwlgnyWPY6L7wrTOCbBQVgZHA to file 1knjOBkHpYy0HQ1QT440qrDiu6dfJxFdXY82HAw5VjjU\n",
+      "Output file id with copying permissions: 1knjOBkHpYy0HQ1QT440qrDiu6dfJxFdXY82HAw5VjjU\n"
+     ]
+    }
+   ],
+   "source": [
+    "new_file_id_with = drive.copy_file(file_from_id=start_file_id, new_file_name='Test_Presentation_With_Permissions', \n",
+    "                                   supports_all_drives=True, transfer_permissions=True)\n",
+    "print('Output file id with copying permissions:', new_file_id_with)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can attest by trying to access this [file](https://docs.google.com/presentation/d/1knjOBkHpYy0HQ1QT440qrDiu6dfJxFdXY82HAw5VjjU/), the permissions have been carried over and now everyone with the link has viewer access to it."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.8.0 64-bit",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Hi @vperezb,

after the exchange we had last week, I had the chance of working on the solution that you suggested.
I am sending you a PR in case you'd like to include these changes into your library.

There are the following changes:
* new function `retrieve_permissions` to extract permissions of a file (taken from  [DriveAPI](https://developers.google.com/drive/api/v2/reference/permissions/list) )
* new function `insert_permission` to insert a new permission into a file (rework of the V2 version shown [here](https://developers.google.com/drive/api/v2/reference/permissions/insert)
* new function `copy_permissions` which is a combination of the two previous functions and takes the permissions of one file and puts them into another (unless transfer ownership is not allowed, in which case the owner because a writer)
* added the argument `transfer_permissions` into the function `copy_file` which uses the latter function to transfer permissions to the file copy
* created an example notebook to show how this argument changes the result

Looking forward to hearing your feedback :)