### PR TITLE
Adding function to upload a file of any type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ __pycache__/
 # Virtual Environments
 Env/
 venv/
+myenv/
 
 # Notebooks
 **/.ipynb_checkpoints/

--- a/GoogleApiSupport/drive.py
+++ b/GoogleApiSupport/drive.py
@@ -221,11 +221,12 @@ def upload_file_to_drive(file_name: str, parent_folder_id: list, local_file_path
             media_body=media_content,
             supportsAllDrives=True).execute()
         
+        file_id = file['id']
+        file_url = f"https://drive.google.com/file/d/{file_id}/view"
+        
         if not parent_folder_id:
             service.permissions().create(fileId=file_id,
                                          body={"role": "reader", "type": "anyone", "withLink": True}).execute()
-        file_id = file['id']
-        file_url = f"https://drive.google.com/file/d/{file_id}/view"
 
     except Exception as e:
         print(f'Error: {e}')

--- a/GoogleApiSupport/drive.py
+++ b/GoogleApiSupport/drive.py
@@ -185,7 +185,7 @@ def upload_image(image_name: str, image_file_path: str, folder_destination_id=No
     return {'image_url': image_url, 'file_id': file_id}
 
 
-def upload_file_to_drive(file_name: str, parent_folder_id: list, local_file_path=None, buffer=None, mime_type=None):
+def upload_file(file_name: str, parent_folder_id: list, local_file_path=None, buffer=None, mime_type=None):
     """ Upload a new file of any type to the drive
     Args:
     file_name: the name you would like to use in google drive

--- a/GoogleApiSupport/drive.py
+++ b/GoogleApiSupport/drive.py
@@ -1,5 +1,7 @@
 from GoogleApiSupport import auth
 from apiclient import errors
+from googleapiclient.http import MediaFileUpload
+import mimetypes
 
 # Permissions functions
 
@@ -180,6 +182,55 @@ def upload_image(image_name: str, image_file_path: str, folder_destination_id=No
         move_file(file_id=file_id, folder_destination_id=folder_destination_id)
 
     return {'image_url': image_url, 'file_id': file_id}
+
+
+def upload_file_to_drive(file_name: str, parent_folder_id: list, local_file_path=None, buffer=None, mime_type=None):
+    """ Upload a new file of any type to the drive
+    Args:
+    file_name: the name you would like to use in google drive
+    parent_folder_id: optional list of the parent folder id. Without this, it will give access to anyone with the link
+    local_file_path: if uploading a local file, you provide the path here
+    buffer: if uploading a file stored in memory, provide a BytesIO object
+    mime_typ: required if providing a buffer, optional if using a local file path
+    Returns:
+    A dictionary with the file_url and file_id
+    """
+    service = auth.get_service("drive")
+    try:
+        if local_file_path and buffer:
+            print("Error: Please provide a local file path OR a buffer")
+            return None
+        if local_file_path:
+            if not mime_type:
+                mime_type, _ = mimetypes.guess_type(local_file_path)
+            media_content = MediaFileUpload(local_file_path)
+            request_body = {'name': file_name, 
+                            'mimeType': mime_type, 
+                           }
+        if buffer:
+            media_content = MediaIoBaseUpload(buffer, mime_type)
+            request_body = {'name': file_name, 
+                            'mimeType': mime_type, 
+                           }
+        if parent_folder_id:
+            request_body['parents'] = parent_folder_id
+        
+        file = service.files().create(
+            body=request_body, 
+            media_body=media_content,
+            supportsAllDrives=True).execute()
+        
+        if not parent_folder_id:
+            service.permissions().create(fileId=file_id,
+                                         body={"role": "reader", "type": "anyone", "withLink": True}).execute()
+        file_id = file['id']
+        file_url = f"https://drive.google.com/file/d/{file_id}/view"
+
+    except Exception as e:
+        print(f'Error: {e}')
+        return None
+
+    return {'file_url': file_url, 'file_id': file_id}
 
 
 def create_folder(name, parent_folder: list = list()):

--- a/GoogleApiSupport/drive.py
+++ b/GoogleApiSupport/drive.py
@@ -1,6 +1,7 @@
 from GoogleApiSupport import auth
 from apiclient import errors
 from googleapiclient.http import MediaFileUpload
+from googleapiclient.http import MediaIoBaseUpload
 import mimetypes
 
 # Permissions functions


### PR DESCRIPTION
I need a function that would allow the upload of any file type (including files stored in memory as bytes). This function allows for the input of a local file path or a buffer. Depending on what is provided, it will go through a different workflow. If there is no parent file id, it will allow anyone with the link to access the file. 

For the future, it might be nice to be able to add or copy permissions for this - but it didn't feel necessary for the first version. Please let me know if you need any other info!

Additionally, I added the new python virtual env `myenv` to the gitignore. 